### PR TITLE
Fix code scanning alert no. 1: Cross-site scripting

### DIFF
--- a/subproject/service-b/build.gradle
+++ b/subproject/service-b/build.gradle
@@ -33,6 +33,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.apache.commons:commons-text:1.12.0'
     providedCompile 'org.eclipse.microprofile:microprofile:7.0'
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api:6.1.0'

--- a/subproject/service-b/src/main/java/com/ibm/app/demo/client/ServiceController.java
+++ b/subproject/service-b/src/main/java/com/ibm/app/demo/client/ServiceController.java
@@ -3,6 +3,7 @@ package com.ibm.app.demo.client;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
+import org.apache.commons.text.StringEscapeUtils;
 
 @Path("/client/service")
 public class ServiceController {
@@ -10,6 +11,7 @@ public class ServiceController {
     @GET
     @Path("/{parameter}")
     public String doSomething(@PathParam("parameter") String parameter) {
-        return String.format("Processed parameter value '%s'", parameter);
+        String safeParameter = StringEscapeUtils.escapeHtml4(parameter);
+        return String.format("Processed parameter value '%s'", safeParameter);
     }
 }


### PR DESCRIPTION
Fixes [https://github.com/marc-pan/kg-cicada/security/code-scanning/1](https://github.com/marc-pan/kg-cicada/security/code-scanning/1)

To fix the cross-site scripting vulnerability, we need to ensure that the user-provided input (`parameter`) is properly sanitized or encoded before being included in the response. The best way to do this is to use a library that provides HTML encoding to prevent XSS attacks.

In this case, we can use the `StringEscapeUtils` class from the Apache Commons Text library to encode the `parameter` value. This will ensure that any potentially malicious content is rendered harmless when included in the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
